### PR TITLE
fix: update text in form description for credit card data collection

### DIFF
--- a/TransbankSdkDotnetExample/Views/TransaccionCompletaDiferida/Index.cshtml
+++ b/TransbankSdkDotnetExample/Views/TransaccionCompletaDiferida/Index.cshtml
@@ -15,7 +15,7 @@
 
 <h1>Transacción Completa Diferida - Formulario</h1>
 <p class="mb-32">
-    En esta primera etapa necesitas obtener los datos esenciales de la tarjeta de crédito, débito o prepago del titular. Utiliza el formulario para recolectar esta información de manera segura.
+    En esta primera etapa necesitas obtener los datos esenciales de la tarjeta de crédito del titular. Utiliza el formulario para recolectar esta información de manera segura.
 </p>
 <div class="tbk-shadow-2 tbk-card large ">
     <form id="card-form" method="POST" action="/transaccion-completa-diferida/create">

--- a/TransbankSdkDotnetExample/Views/TransaccionCompletaMallDiferido/Index.cshtml
+++ b/TransbankSdkDotnetExample/Views/TransaccionCompletaMallDiferido/Index.cshtml
@@ -15,7 +15,7 @@
 
 <h1>Transacción Completa Mall Diferido - Formulario</h1>
 <p class="mb-32">
-    En esta primera etapa necesitas obtener los datos esenciales de la tarjeta de crédito, débito o prepago del titular. Utiliza el formulario para recolectar esta información de manera segura.
+    En esta primera etapa necesitas obtener los datos esenciales de la tarjeta de crédito del titular. Utiliza el formulario para recolectar esta información de manera segura.
 </p>
 <div class="tbk-shadow-2 tbk-card large ">
     <form id="card-form" method="POST" action="/transaccion-completa-mall-diferido/create">


### PR DESCRIPTION
This pull request updates the instructional text in the forms for "Transacción Completa Diferida" and "Transacción Completa Mall Diferido" to clarify that only credit card information is required, removing references to debit and prepaid cards.

<img width="1259" height="171" alt="image" src="https://github.com/user-attachments/assets/2022f023-b900-4748-b0b4-60c9fa9fa781" />
